### PR TITLE
add usecase to set external camera ip [#55]

### DIFF
--- a/data/src/main/java/com/foke/together/data/datasource/local/datastore/AppPreferencesSerializer.kt
+++ b/data/src/main/java/com/foke/together/data/datasource/local/datastore/AppPreferencesSerializer.kt
@@ -14,7 +14,7 @@ class AppPreferencesSerializer @Inject constructor(): Serializer<AppPreferences>
             // Add proto datastore default value here.
             // You need to check default value of each types from link below
             // https://protobuf.dev/programming-guides/proto3/
-            // ex> isDebugMode = true
+            // e.g. isDebugMode = true
             externalCameraIp = AppPolicy.DEFAULT_EXTERNAL_CAMERA_IP
             build()
         }

--- a/data/src/main/java/com/foke/together/data/datasource/local/datastore/AppPreferencesSerializer.kt
+++ b/data/src/main/java/com/foke/together/data/datasource/local/datastore/AppPreferencesSerializer.kt
@@ -3,6 +3,7 @@ package com.foke.together.data.datasource.local.datastore
 import androidx.datastore.core.Serializer
 import com.foke.together.AppPreferences
 import com.foke.together.util.AppLog
+import com.foke.together.util.AppPolicy
 import java.io.InputStream
 import java.io.OutputStream
 import javax.inject.Inject
@@ -14,6 +15,7 @@ class AppPreferencesSerializer @Inject constructor(): Serializer<AppPreferences>
             // You need to check default value of each types from link below
             // https://protobuf.dev/programming-guides/proto3/
             // ex> isDebugMode = true
+            externalCameraIp = AppPolicy.DEFAULT_EXTERNAL_CAMERA_IP
             build()
         }
 

--- a/data/src/main/java/com/foke/together/data/repository/AppPreferencesRepository.kt
+++ b/data/src/main/java/com/foke/together/data/repository/AppPreferencesRepository.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import com.foke.together.AppPreferences
 import com.foke.together.CameraSource
 import com.foke.together.domain.interactor.entity.CameraSourceType
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
 import com.foke.together.domain.output.AppPreferenceInterface
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -36,6 +37,24 @@ class AppPreferencesRepository @Inject constructor(
                     .setCameraSource(this)
                     .build()
             }
+        }
+    }
+
+    override fun getExternalCameraIP(): Flow<ExternalCameraIP> =
+        appPreferencesFlow.map {
+            val address = it.externalCameraIp
+            if (address.isNullOrEmpty()) {
+                ExternalCameraIP("0.0.0.0")
+            } else {
+                ExternalCameraIP(address)
+            }
+        }
+
+    override suspend fun setExternalCameraIP(ip: ExternalCameraIP) {
+        appPreferences.updateData {
+            it.toBuilder()
+                .setExternalCameraIp(ip.address)
+                .build()
         }
     }
 

--- a/data/src/main/java/com/foke/together/data/repository/AppPreferencesRepository.kt
+++ b/data/src/main/java/com/foke/together/data/repository/AppPreferencesRepository.kt
@@ -42,12 +42,7 @@ class AppPreferencesRepository @Inject constructor(
 
     override fun getExternalCameraIP(): Flow<ExternalCameraIP> =
         appPreferencesFlow.map {
-            val address = it.externalCameraIp
-            if (address.isNullOrEmpty()) {
-                ExternalCameraIP("0.0.0.0")
-            } else {
-                ExternalCameraIP(address)
-            }
+            ExternalCameraIP(it.externalCameraIp)
         }
 
     override suspend fun setExternalCameraIP(ip: ExternalCameraIP) {

--- a/data/src/main/proto/app_preferences.proto
+++ b/data/src/main/proto/app_preferences.proto
@@ -13,6 +13,7 @@ message AppPreferences {
     // * Max size of field number is 536870911
 
     CameraSource camera_source = 10;
+    string external_camera_ip = 11;
 
     // TODO: sample code. remove later.
     string sample_id = 999997;

--- a/domain/src/main/java/com/foke/together/domain/input/GetExternalCameraIPInterface.kt
+++ b/domain/src/main/java/com/foke/together/domain/input/GetExternalCameraIPInterface.kt
@@ -1,0 +1,8 @@
+package com.foke.together.domain.input
+
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
+import kotlinx.coroutines.flow.Flow
+
+interface GetExternalCameraIPInterface {
+    operator fun invoke(): Flow<ExternalCameraIP>
+}

--- a/domain/src/main/java/com/foke/together/domain/input/SetExternalCameraIPInterface.kt
+++ b/domain/src/main/java/com/foke/together/domain/input/SetExternalCameraIPInterface.kt
@@ -1,0 +1,7 @@
+package com.foke.together.domain.input
+
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
+
+interface SetExternalCameraIPInterface {
+    suspend operator fun invoke(externalCameraIP: ExternalCameraIP)
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraIPUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraIPUseCase.kt
@@ -1,0 +1,18 @@
+package com.foke.together.domain.interactor
+
+
+import com.foke.together.domain.input.GetExternalCameraIPInterface
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
+import com.foke.together.domain.output.AppPreferenceInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetExternalCameraIPUseCase @Inject constructor(
+    private val appPreference: AppPreferenceInterface
+): GetExternalCameraIPInterface {
+    override fun invoke(): Flow<ExternalCameraIP> =
+        appPreference.getExternalCameraIP().map { it }
+}
+
+

--- a/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraIPUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraIPUseCase.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class GetExternalCameraIPUseCase @Inject constructor(
     private val appPreference: AppPreferenceInterface
 ): GetExternalCameraIPInterface {
-    override fun invoke(): Flow<ExternalCameraIP> =
+    override operator fun invoke(): Flow<ExternalCameraIP> =
         appPreference.getExternalCameraIP().map { it }
 }
 

--- a/domain/src/main/java/com/foke/together/domain/interactor/SetExternalCameraIPUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/SetExternalCameraIPUseCase.kt
@@ -1,0 +1,16 @@
+package com.foke.together.domain.interactor
+
+
+import com.foke.together.domain.input.SetExternalCameraIPInterface
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
+import com.foke.together.domain.output.AppPreferenceInterface
+import javax.inject.Inject
+
+class SetExternalCameraIPUseCase @Inject constructor(
+    private val appPreference: AppPreferenceInterface
+): SetExternalCameraIPInterface {
+    override suspend operator fun invoke(externalCameraIP: ExternalCameraIP)=
+        appPreference.setExternalCameraIP(externalCameraIP)
+}
+
+

--- a/domain/src/main/java/com/foke/together/domain/interactor/entity/ExternalCameraIP.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/entity/ExternalCameraIP.kt
@@ -1,0 +1,5 @@
+package com.foke.together.domain.interactor.entity
+
+data class ExternalCameraIP (
+    val address: String,
+)

--- a/domain/src/main/java/com/foke/together/domain/output/AppPreferenceInterface.kt
+++ b/domain/src/main/java/com/foke/together/domain/output/AppPreferenceInterface.kt
@@ -1,11 +1,15 @@
 package com.foke.together.domain.output
 
 import com.foke.together.domain.interactor.entity.CameraSourceType
+import com.foke.together.domain.interactor.entity.ExternalCameraIP
 import kotlinx.coroutines.flow.Flow
 
 interface AppPreferenceInterface {
     fun getCameraSourceType(): Flow<CameraSourceType>
     suspend fun setCameraSourceType(type: CameraSourceType)
+
+    fun getExternalCameraIP(): Flow<ExternalCameraIP>
+    suspend fun setExternalCameraIP(ip: ExternalCameraIP)
 
     suspend fun clearAll()
 }

--- a/presenter/src/main/java/com/foke/together/presenter/theme/Shape.kt
+++ b/presenter/src/main/java/com/foke/together/presenter/theme/Shape.kt
@@ -1,4 +1,4 @@
 package com.foke.together.presenter.theme
 
 // Defines commonly used or recycled values
-// ex> https://github.com/android/compose-samples/blob/main/JetNews/app/src/main/java/com/example/jetnews/ui/theme/Shape.kt
+// e.g. https://github.com/android/compose-samples/blob/main/JetNews/app/src/main/java/com/example/jetnews/ui/theme/Shape.kt

--- a/util/src/main/java/com/foke/together/util/AppPolicy.kt
+++ b/util/src/main/java/com/foke/together/util/AppPolicy.kt
@@ -1,0 +1,5 @@
+package com.foke.together.util
+
+object AppPolicy {
+    const val DEFAULT_EXTERNAL_CAMERA_IP = "0.0.0.0"
+}


### PR DESCRIPTION
[Issue] #55 
[Descriptions]
- adds GetExternalCameraIPUseCase
- adds SetExternalCameraIPUseCase
- adds `ExternalCameraIP` entity with single address String