### PR TITLE
add UseCases for external camera [#58]

### DIFF
--- a/domain/src/main/java/com/foke/together/domain/interactor/CaptureWithExternalCameraUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/CaptureWithExternalCameraUseCase.kt
@@ -1,0 +1,31 @@
+package com.foke.together.domain.interactor
+
+import com.foke.together.domain.output.ExternalCameraRepositoryInterface
+import com.foke.together.util.AppLog
+import javax.inject.Inject
+
+class CaptureWithExternalCameraUseCase @Inject constructor(
+    private val externalCameraRepository: ExternalCameraRepositoryInterface
+) {
+    suspend operator fun invoke(): Result<Unit> {
+        externalCameraRepository.capture()
+            .onSuccess {
+                // TODO: save Bitmap to internal storage
+                AppLog.i(TAG, "capture", "success: $it")
+
+                // TODO: implement file save code here ...
+
+                return Result.success(Unit)
+            }
+            .onFailure {
+                // TODO: handle network error
+                AppLog.i(TAG, "capture", "failure: $it")
+                return Result.failure(it)
+            }
+        return Result.failure(Exception("Unknown error"))
+    }
+
+    companion object {
+        private val TAG = CaptureWithExternalCameraUseCase::class.java.simpleName
+    }
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraPreviewUrlUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/GetExternalCameraPreviewUrlUseCase.kt
@@ -1,0 +1,10 @@
+package com.foke.together.domain.interactor
+
+import com.foke.together.domain.output.ExternalCameraRepositoryInterface
+import javax.inject.Inject
+
+class GetExternalCameraPreviewUrlUseCase @Inject constructor(
+    private val externalCameraRepository: ExternalCameraRepositoryInterface
+) {
+    operator fun invoke() = externalCameraRepository.getPreviewUrl()
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/InitExternalCameraIPUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/InitExternalCameraIPUseCase.kt
@@ -1,16 +1,17 @@
 package com.foke.together.domain.interactor
 
-import com.foke.together.domain.interactor.entity.ExternalCameraIP
 import com.foke.together.domain.output.AppPreferenceInterface
 import com.foke.together.domain.output.ExternalCameraRepositoryInterface
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
-class SetExternalCameraIPUseCase @Inject constructor(
+class InitExternalCameraIPUseCase @Inject constructor(
     private val appPreference: AppPreferenceInterface,
     private val externalCameraRepository: ExternalCameraRepositoryInterface
 ) {
-    suspend operator fun invoke(externalCameraIP: ExternalCameraIP) {
-        appPreference.setExternalCameraIP(externalCameraIP)
-        externalCameraRepository.setCameraSourceUrl(externalCameraIP.address)
+    suspend operator fun invoke() {
+        appPreference.getExternalCameraIP().firstOrNull()?.let { externalCameraIP ->
+            externalCameraRepository.setCameraSourceUrl(externalCameraIP.address)
+        }
     }
 }


### PR DESCRIPTION
[Issue] #58
[Descriptions]
- CaptureWithExternalCameraUseCase
   - 외부 카메라로 캡쳐 후 파일로 저장 및 저장 위치 return
- GetExternalCameraPreviewUrlUseCase
   - 외부 카메라 프리뷰 주소 가져옴
- InitExternalCameraIPUseCase
   - 앱 실행 시, 외부 카메라 IP를 sharedPref. 에 저장된 값으로 설정
- SetExternalCameraIPUseCase (수정)
   - 외부 카메라 IP 수정 시, retrofit baseUrl도 변경