### PR TITLE
add UseCases for web communications [#73]

### DIFF
--- a/data/src/main/java/com/foke/together/data/datasource/remote/WebClientApi.kt
+++ b/data/src/main/java/com/foke/together/data/datasource/remote/WebClientApi.kt
@@ -22,7 +22,7 @@ interface WebClientApi {
         @Body body: AccountRegisterRequest
     ): Result<AccountRegisterResponse>
 
-    @GET("api/account/register")
+    @GET("api/account/signin")
     suspend fun accountSignin(
         @Query("email") email: String,
         @Query("password") password: String
@@ -37,7 +37,7 @@ interface WebClientApi {
     @GET("api/s3/presigned-url")
     suspend fun s3PresignedUrl(
         @HeaderMap headers: HashMap<String, String>,
-        @Query("key") key: String,
+        @Query("filename") filename: String,
         @Query("ContentLength") contentLength: String, // max: 20971520
     ): Result<S3PresignedUrlResponse>
 

--- a/data/src/main/java/com/foke/together/data/datasource/remote/WebDataSource.kt
+++ b/data/src/main/java/com/foke/together/data/datasource/remote/WebDataSource.kt
@@ -35,14 +35,14 @@ class WebDataSource @Inject constructor(
         return Result.failure(Exception("unknown error"))
     }
 
-    suspend fun s3PreSignedUrl(key: String, file: File): Result<S3PresignedUrlResponse> {
+    suspend fun s3PreSignedUrl(filename: String, file: File): Result<S3PresignedUrlResponse> {
         val contentLength = file.length()
         if (contentLength > AppPolicy.WEB_FILE_MAX_CONTENT_LENGTH) {
             return Result.failure(Exception("file size is over limit"))
         }
         return webClientApi.s3PresignedUrl(
             headers = headers,
-            key = key,
+            filename = filename,
             contentLength = file.length().toString()
         )
     }
@@ -57,6 +57,6 @@ class WebDataSource @Inject constructor(
     }
 
     private fun setToken(token: String) {
-        headers["token"] = token
+        headers["Authorization"] = "Bearer $token"
     }
 }

--- a/data/src/main/java/com/foke/together/data/repository/AccountRepository.kt
+++ b/data/src/main/java/com/foke/together/data/repository/AccountRepository.kt
@@ -1,0 +1,22 @@
+package com.foke.together.data.repository
+
+import com.foke.together.domain.interactor.entity.AccountData
+import com.foke.together.domain.output.AccountRepositoryInterface
+import javax.inject.Inject
+
+class AccountRepository @Inject constructor(
+) : AccountRepositoryInterface {
+    private var accountData: AccountData? = null
+
+    override suspend fun setAccountInfo(data: AccountData) {
+        accountData = data
+    }
+
+    override suspend fun getAccountInfo(): Result<AccountData> {
+        return accountData?.run {
+            Result.success(this)
+        } ?: run {
+            Result.failure(Exception("account data is null"))
+        }
+    }
+}

--- a/data/src/main/java/com/foke/together/data/repository/RemoteRepository.kt
+++ b/data/src/main/java/com/foke/together/data/repository/RemoteRepository.kt
@@ -38,8 +38,8 @@ class RemoteRepository @Inject constructor(
         return Result.failure(Exception("unknown error"))
     }
 
-    override suspend fun getUploadUrl(key: String, file: File): Result<String> {
-        webDataSource.s3PreSignedUrl(key, file)
+    override suspend fun getUploadUrl(filename: String, file: File): Result<String> {
+        webDataSource.s3PreSignedUrl(filename, file)
             .onSuccess {
                 return Result.success(it.presignedUrl)
             }

--- a/data/src/main/java/com/foke/together/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/foke/together/data/repository/di/RepositoryModule.kt
@@ -7,14 +7,17 @@ import com.foke.together.domain.output.RemoteRepositoryInterface
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+    @Singleton
     @Binds
     abstract fun bindAppPreferenceRepository(appPreferenceRepository: AppPreferencesRepository): AppPreferenceInterface
 
+    @Singleton
     @Binds
     abstract fun bindRemoteRepository(remoteRepository: RemoteRepository): RemoteRepositoryInterface
 }

--- a/data/src/main/java/com/foke/together/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/foke/together/data/repository/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.foke.together.data.repository.di
 
+import com.foke.together.data.repository.AccountRepository
 import com.foke.together.data.repository.AppPreferencesRepository
 import com.foke.together.data.repository.RemoteRepository
+import com.foke.together.domain.output.AccountRepositoryInterface
 import com.foke.together.domain.output.AppPreferenceInterface
 import com.foke.together.domain.output.RemoteRepositoryInterface
 import dagger.Binds
@@ -20,4 +22,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindRemoteRepository(remoteRepository: RemoteRepository): RemoteRepositoryInterface
+
+    @Singleton
+    @Binds
+    abstract fun bindAccountRepository(accountRepository: AccountRepository): AccountRepositoryInterface
 }

--- a/domain/src/main/java/com/foke/together/domain/interactor/entity/AccountData.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/entity/AccountData.kt
@@ -3,5 +3,5 @@ package com.foke.together.domain.interactor.entity
 data class AccountData (
     val email: String,
     val password: String,
-    val name: String?
+    val name: String? = null
 )

--- a/domain/src/main/java/com/foke/together/domain/interactor/web/CreateAccountUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/web/CreateAccountUseCase.kt
@@ -1,0 +1,13 @@
+package com.foke.together.domain.interactor.web
+
+import com.foke.together.domain.output.RemoteRepositoryInterface
+import javax.inject.Inject
+
+class CreateAccountUseCase @Inject constructor(
+    private val remoteRepository: RemoteRepositoryInterface
+)  {
+    operator fun invoke(id: String, password: String): Result<Unit> {
+        // TODO: implement in sprint4
+        return Result.failure(Exception("not implemented"))
+    }
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/web/GetCurrentUserInformationUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/web/GetCurrentUserInformationUseCase.kt
@@ -1,0 +1,20 @@
+package com.foke.together.domain.interactor.web
+
+import com.foke.together.domain.interactor.entity.AccountData
+import com.foke.together.domain.output.AccountRepositoryInterface
+import com.foke.together.domain.output.RemoteRepositoryInterface
+import javax.inject.Inject
+
+class GetCurrentUserInformationUseCase @Inject constructor(
+    private val remoteRepository: RemoteRepositoryInterface,
+    private val accountRepository: AccountRepositoryInterface
+) {
+    suspend operator fun invoke(): Result<AccountData> =
+        accountRepository.getAccountInfo()
+            .onFailure {
+                remoteRepository.getAccountStatus()
+                    .onSuccess {
+                        accountRepository.setAccountInfo(it)
+                    }
+            }
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/web/SignInUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/web/SignInUseCase.kt
@@ -1,0 +1,26 @@
+package com.foke.together.domain.interactor.web
+
+import com.foke.together.domain.interactor.entity.AccountData
+import com.foke.together.domain.output.AccountRepositoryInterface
+import com.foke.together.domain.output.RemoteRepositoryInterface
+import javax.inject.Inject
+
+class SignInUseCase @Inject constructor(
+    private val remoteRepository: RemoteRepositoryInterface,
+    private val accountRepository: AccountRepositoryInterface,
+    private val getCurrentUserInformationUseCase: GetCurrentUserInformationUseCase
+) {
+    suspend operator fun invoke(id: String, password: String): Result<Unit> {
+        return remoteRepository.signIn(AccountData(id, password))
+            .onSuccess {
+                getCurrentUserInformationUseCase()
+                    .onSuccess { accountData ->
+                        accountRepository.setAccountInfo(AccountData(
+                            email = accountData.email,
+                            password = "",
+                            name = accountData.name
+                        ))
+                    }
+            }
+    }
+}

--- a/domain/src/main/java/com/foke/together/domain/interactor/web/UploadFileUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/web/UploadFileUseCase.kt
@@ -1,0 +1,28 @@
+package com.foke.together.domain.interactor.web
+
+import com.foke.together.domain.output.RemoteRepositoryInterface
+import com.foke.together.util.AppLog
+import java.io.File
+import javax.inject.Inject
+
+// Download url
+// https://4cuts.store/download/{user_name}/{key}
+class UploadFileUseCase @Inject constructor(
+    private val remoteRepository: RemoteRepositoryInterface
+) {
+    suspend operator fun invoke(key: String, file: File): Result<Unit> {
+        remoteRepository.getUploadUrl("$key.${file.extension}", file)
+            .onSuccess { preSignedUrl ->
+                AppLog.e("UploadFileUseCase", "invoke", "preSignedUrl: $preSignedUrl")
+                remoteRepository.uploadFile(preSignedUrl, file)
+                    .onFailure {
+                        AppLog.e("UploadFileUseCase", "invoke", "upload failed")
+                        return Result.failure(Exception("cannot upload file: $it"))
+                    }
+            }
+            .onFailure {
+                return Result.failure(Exception("cannot get pre-signed url: $it"))
+            }
+        return Result.failure(Exception("Unknown error"))
+    }
+}

--- a/domain/src/main/java/com/foke/together/domain/output/AccountRepositoryInterface.kt
+++ b/domain/src/main/java/com/foke/together/domain/output/AccountRepositoryInterface.kt
@@ -1,0 +1,8 @@
+package com.foke.together.domain.output
+
+import com.foke.together.domain.interactor.entity.AccountData
+
+interface AccountRepositoryInterface {
+    suspend fun setAccountInfo(data: AccountData)
+    suspend fun getAccountInfo(): Result<AccountData>
+}

--- a/domain/src/main/java/com/foke/together/domain/output/RemoteRepositoryInterface.kt
+++ b/domain/src/main/java/com/foke/together/domain/output/RemoteRepositoryInterface.kt
@@ -7,6 +7,6 @@ interface RemoteRepositoryInterface {
     suspend fun registerAccount(data: AccountData): Result<Unit>
     suspend fun signIn(data: AccountData): Result<Unit>
     suspend fun getAccountStatus(): Result<AccountData>
-    suspend fun getUploadUrl(key: String, file: File): Result<String>
+    suspend fun getUploadUrl(filename: String, file: File): Result<String>
     suspend fun uploadFile(preSignedUrl: String, file: File): Result<Unit>
 }

--- a/external/src/main/java/com/foke/together/external/repository/di/RepositoryModule.kt
+++ b/external/src/main/java/com/foke/together/external/repository/di/RepositoryModule.kt
@@ -5,11 +5,13 @@ import com.foke.together.external.repository.ExternalCameraRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+    @Singleton
     @Binds
     abstract fun bindAppPreferenceRepository(
         externalCameraRepository: ExternalCameraRepository

--- a/util/src/main/java/com/foke/together/util/AppPolicy.kt
+++ b/util/src/main/java/com/foke/together/util/AppPolicy.kt
@@ -6,7 +6,7 @@ object AppPolicy {
     const val DEFAULT_EXTERNAL_CAMERA_IP = "0.0.0.0"
 
     // network
-    const val WEB_SERVER_URL = "http://4cuts.store/"
+    const val WEB_SERVER_URL = "https://4cuts.store/"
     const val WEB_CONNECT_TIMEOUT = 10L
     const val WEB_READ_TIMEOUT = 10L
     const val WEB_WRITE_TIMEOUT = 10L


### PR DESCRIPTION
- [Issue] #73 
- [Descriptions]
  - 서버와 통신하기 위한 usecase들을 추가
      - **CreateAccountUseCase**: 계정 생성 (`phase4` 구현)
      - **SignInUseCase**: 로그인 및 세션 생성
      - **GetCurrentUserInformationUseCase**: 현재 로그인된 세센 계정 정보
      - **UploadFileUseCase**: 파일을 pre-signed url을 통해 업로드
  - https://4cuts.store/docs 내용 기반