### PR TITLE
bug fix. net work logger block communications [#85]

### DIFF
--- a/util/src/main/java/com/foke/together/util/retrofit/NetworkCall.kt
+++ b/util/src/main/java/com/foke/together/util/retrofit/NetworkCall.kt
@@ -3,7 +3,6 @@ package com.foke.together.util.retrofit
 import com.foke.together.util.AppLog
 import com.foke.together.util.AppPolicy
 import okhttp3.Request
-import okhttp3.ResponseBody
 import okio.IOException
 import okio.Timeout
 import retrofit2.Call
@@ -17,15 +16,14 @@ class NetworkCall<T>(
         call.enqueue(object: Callback<T> {
             override fun onResponse(call: Call<T>, response: Response<T>) {
                 if (AppPolicy.isDebugMode) {
-                    AppLog.e(TAG, "onResponse", "success: $response")
-                    AppLog.e(TAG, "onResponse", "success: ${response.headers()}")
-
-                    val body = response.body() as ResponseBody
-                    AppLog.e(TAG, "onResponse", "success: ${response.body()}")
-                    AppLog.e(TAG, "onResponse", "success: ${body.source()}")
-                    AppLog.e(TAG, "onResponse", "success: ${body.contentLength()}")
-                    AppLog.e(TAG, "onResponse", "success: ${body.contentType()}")
-                    AppLog.e(TAG, "onResponse", "success: ${body.bytes()}")
+                    AppLog.e(TAG, "onResponse", ">>>>>>>>>>>>>>>>> start >>>>>>>>>>>>>>>>>")
+                    AppLog.e(TAG, "onResponse", "response: $response")
+                    AppLog.e(TAG, "onResponse", "headers: ${response.headers()}")
+                    response.raw().body?.run {
+                        AppLog.e(TAG, "onResponse", "contentType: ${this.contentType()}")
+                        AppLog.e(TAG, "onResponse", "contentLength: ${this.contentLength()}")
+                    }
+                    AppLog.e(TAG, "onResponse", "<<<<<<<<<<<<<<<<<< end <<<<<<<<<<<<<<<<")
                 }
 
                 if (response.isSuccessful) {


### PR DESCRIPTION
- **[Issue]** #85
- **[Descriptions]**
   - 네트워크 로그가 `body.source()`, `body.bytes()` 호출하면서 네트워크 호출 자체를 block 하는 이슈 해결