### PR TITLE
bug fix. getCurrentUserInformationUseCase return nothings [#85]

### DIFF
--- a/domain/src/main/java/com/foke/together/domain/interactor/web/GetDownloadUrlUseCase.kt
+++ b/domain/src/main/java/com/foke/together/domain/interactor/web/GetDownloadUrlUseCase.kt
@@ -11,7 +11,7 @@ class GetDownloadUrlUseCase @Inject constructor(
     suspend operator fun invoke(key: String): Result<String> {
         getCurrentUserInformationUseCase()
             .onSuccess {
-                "${AppPolicy.WEB_SERVER_URL}download/${it.name}/$key"
+                return Result.success("${AppPolicy.WEB_SERVER_URL}download/${it.name}/$key.jpg") // TODO: remove `.jpg` later
             }
         return Result.failure(Exception("Unknown error"))
     }


### PR DESCRIPTION
- **[Issue]** #85
- **[Descriptions]**
   - getCurrentUserInformationUseCase가 path를 return하지 않았던 버그를 수정