### PR TITLE
bugfix. timing issue to upload images [#116]

### DIFF
--- a/presenter/src/main/java/com/foke/together/presenter/viewmodel/GenerateSingleRowImageViewModel.kt
+++ b/presenter/src/main/java/com/foke/together/presenter/viewmodel/GenerateSingleRowImageViewModel.kt
@@ -1,28 +1,18 @@
 package com.foke.together.presenter.viewmodel
 
-import android.content.Context
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
-import androidx.core.net.toFile
 import androidx.lifecycle.ViewModel
 import com.foke.together.domain.interactor.GeneratePhotoFrameUseCase
-import com.foke.together.domain.interactor.GetQRCodeUseCase
 import com.foke.together.domain.interactor.entity.CutFrameType
-import com.foke.together.domain.interactor.web.SessionKeyUseCase
-import com.foke.together.domain.interactor.web.UploadFileUseCase
 import com.foke.together.util.AppLog
 import com.foke.together.util.AppPolicy
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 @HiltViewModel
 class GenerateSingleRowImageViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val generatePhotoFrameUseCase: GeneratePhotoFrameUseCase,
-    private val uploadFileUseCase: UploadFileUseCase,
-    private val sessionKeyUseCase: SessionKeyUseCase,
-    private val getQRCodeUseCase: GetQRCodeUseCase
 ): ViewModel() {
     val cutFrameType: CutFrameType = generatePhotoFrameUseCase.getCutFrameType()
     val imageUri = generatePhotoFrameUseCase.getCapturedImageListUri()
@@ -30,8 +20,6 @@ class GenerateSingleRowImageViewModel @Inject constructor(
     suspend fun generateImage(graphicsLayer: GraphicsLayer) {
         val bitmap = graphicsLayer.toImageBitmap().asAndroidBitmap()
         val finalCachedImageUri = generatePhotoFrameUseCase.saveGraphicsLayerImage(bitmap, AppPolicy.SINGLE_ROW_FINAL_IMAGE_NAME)
-        val result = uploadFileUseCase(sessionKeyUseCase.getSessionKey(), finalCachedImageUri.toFile())
         AppLog.d("GenerateImageViewModel", "generateTwoRowImage" ,"twoRow: $finalCachedImageUri")
-        AppLog.d("GenerateImageViewModel", "UploadFile" ,"result: $result")
     }
 }

--- a/presenter/src/main/java/com/foke/together/presenter/viewmodel/ShareViewModel.kt
+++ b/presenter/src/main/java/com/foke/together/presenter/viewmodel/ShareViewModel.kt
@@ -14,6 +14,7 @@ import com.foke.together.domain.interactor.GeneratePhotoFrameUseCase
 import com.foke.together.domain.interactor.GetQRCodeUseCase
 import com.foke.together.domain.interactor.web.GetDownloadUrlUseCase
 import com.foke.together.domain.interactor.web.SessionKeyUseCase
+import com.foke.together.domain.interactor.web.UploadFileUseCase
 import com.foke.together.util.AppLog
 import com.foke.together.util.AppPolicy
 import com.foke.together.util.ImageFileUtil
@@ -28,6 +29,7 @@ class ShareViewModel @Inject constructor(
     private val getQRCodeUseCase: GetQRCodeUseCase,
     private val getDownloadUrlUseCase: GetDownloadUrlUseCase,
     private val sessionKeyUseCase: SessionKeyUseCase,
+    private val uploadFileUseCase: UploadFileUseCase,
     private val generatePhotoFrameUseCase: GeneratePhotoFrameUseCase
 ): ViewModel() {
     var qrCodeBitmap by mutableStateOf<Bitmap?>(null)
@@ -52,6 +54,8 @@ class ShareViewModel @Inject constructor(
     }
 
     private suspend fun generateQRcode() {
+        val result = uploadFileUseCase(sessionKeyUseCase.getSessionKey(), singleImageUri.toFile())
+        AppLog.d("GenerateImageViewModel", "UploadFile" ,"result: $result")
         val sessionKey = sessionKeyUseCase.getSessionKey()
         val downloadUrl: String = getDownloadUrlUseCase(sessionKey).getOrElse { "https://4cuts.store" }
 


### PR DESCRIPTION
- **[Issue]** #116
- **[Descriptions]**
  - 이미지 업로드를 생명주기가 매우 짧은 `GenerateSingleRowImageView`에서 진행하여 이미지가 업로드 되지 않는 이슈 발생
  - 생명주기가 긴 `ShareView`에서 이미지를 업로드하도록 변경